### PR TITLE
fix: update frontend/backend to check token before render Dashboard components

### DIFF
--- a/backend/src/controllers/authController.ts
+++ b/backend/src/controllers/authController.ts
@@ -7,6 +7,10 @@ import mongoose from 'mongoose';
 // Chave secreta para assinar e verificar o JWT.
 const JWT_SECRET = process.env.JWT_SECRET || 'sua_super_chave_secreta_e_longa_aqui';
 
+export const checkToken = async (_req: Request, res: Response) => {
+  return res.status(200).json({ message: "Token vericado com sucesso" })
+}
+
 export const register = async (req: Request, res: Response) => {
   const { email, password, role } = req.body;
 
@@ -78,47 +82,47 @@ export const login = async (req: Request, res: Response) => {
 };
 
 export const changePassword = async (req: Request, res: Response): Promise<Response> => {
-    const { oldPassword, newPassword } = req.body;
-    const userId = req.user?.id; // Obtido do middleware 'auth'
+  const { oldPassword, newPassword } = req.body;
+  const userId = req.user?.id; // Obtido do middleware 'auth'
 
-    // Validação básica de entrada
-    if (!oldPassword || !newPassword) {
-        return res.status(400).json({ message: 'Senha antiga e nova senha são obrigatórias.' });
+  // Validação básica de entrada
+  if (!oldPassword || !newPassword) {
+    return res.status(400).json({ message: 'Senha antiga e nova senha são obrigatórias.' });
+  }
+
+  if (!userId) {
+    // Isso não deve acontecer se o middleware 'auth' estiver funcionando corretamente
+    return res.status(401).json({ message: 'ID do usuário não encontrado na requisição. Autorização falhou.' });
+  }
+
+  try {
+    const user: IUser | null = await User.findById(userId);
+
+    if (!user) {
+      return res.status(404).json({ message: 'Usuário não encontrado.' });
     }
 
-    if (!userId) {
-        // Isso não deve acontecer se o middleware 'auth' estiver funcionando corretamente
-        return res.status(401).json({ message: 'ID do usuário não encontrado na requisição. Autorização falhou.' });
+    // 1. Verificar a senha antiga
+    const isMatch = await user.comparePassword(oldPassword);
+    if (!isMatch) {
+      return res.status(401).json({ message: 'Senha antiga incorreta.' });
     }
 
-    try {
-        const user: IUser | null = await User.findById(userId);
+    user.password = newPassword; // Atribua a nova senha (ela será criptografada automaticamente)
+    await user.save(); // Salve o usuário, o hook pre('save') será executado
 
-        if (!user) {
-            return res.status(404).json({ message: 'Usuário não encontrado.' });
-        }
+    return res.status(200).json({ message: 'Senha alterada com sucesso.' });
 
-        // 1. Verificar a senha antiga
-        const isMatch = await user.comparePassword(oldPassword);
-        if (!isMatch) {
-            return res.status(401).json({ message: 'Senha antiga incorreta.' });
-        }
-
-        user.password = newPassword; // Atribua a nova senha (ela será criptografada automaticamente)
-        await user.save(); // Salve o usuário, o hook pre('save') será executado
-
-        return res.status(200).json({ message: 'Senha alterada com sucesso.' });
-
-    } catch (error: unknown) {
-        console.error('Erro ao alterar senha:', error);
-        if (error instanceof mongoose.Error.ValidationError) {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            const messages = Object.values(error.errors).map(err => (err as any).message);
-            return res.status(400).json({ message: 'Erro de validação: ' + messages.join(', ') });
-        }
-        if (error instanceof Error) {
-            return res.status(500).json({ message: error.message || 'Erro interno do servidor.' });
-        }
-        return res.status(500).json({ message: 'Ocorreu um erro desconhecido ao alterar a senha.' });
+  } catch (error: unknown) {
+    console.error('Erro ao alterar senha:', error);
+    if (error instanceof mongoose.Error.ValidationError) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const messages = Object.values(error.errors).map(err => (err as any).message);
+      return res.status(400).json({ message: 'Erro de validação: ' + messages.join(', ') });
     }
+    if (error instanceof Error) {
+      return res.status(500).json({ message: error.message || 'Erro interno do servidor.' });
+    }
+    return res.status(500).json({ message: 'Ocorreu um erro desconhecido ao alterar a senha.' });
+  }
 };

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -40,7 +40,7 @@ const auth = (req: Request, res: Response, next: NextFunction) => {
     if (error instanceof jwt.TokenExpiredError) {
       return res.status(401).json({ message: 'Token expirado.' });
     }
-     return res.status(401).json({ message: 'Token inválido, autorização negada.' });
+    return res.status(401).json({ message: 'Token inválido, autorização negada.' });
   }
 };
 

--- a/backend/src/routes/authRoutes.ts
+++ b/backend/src/routes/authRoutes.ts
@@ -1,5 +1,5 @@
 import { Router } from 'express';
-import { register, login, changePassword } from '../controllers/authController'; // Criaremos esses controladores
+import { register, login, changePassword, checkToken } from '../controllers/authController'; // Criaremos esses controladores
 import auth from '../middleware/auth';
 
 const router = Router();
@@ -7,5 +7,6 @@ const router = Router();
 router.post('/register', register); // Rota para registrar um novo usuário
 router.post('/login', login);       // Rota para fazer login
 router.put('/change-password', auth, changePassword); // Rota para alterar senha, PROTEGIDA pelo middleware 'auth'
+router.get('/check-token', auth, checkToken) // rota para checar o token
 
 export default router;

--- a/src/pages/homepage/PrivateRoute.tsx
+++ b/src/pages/homepage/PrivateRoute.tsx
@@ -1,9 +1,23 @@
 import { useSelector } from "react-redux";
-import type { RootState } from "../../stores/appStore";
+import { useAppDispatch, type RootState } from "../../stores/appStore";
 import { Navigate, Outlet } from "react-router-dom";
+import { checkToken } from "../../stores/authStore";
+import { useEffect } from "react";
 
 
-export const PrivateRoute = () =>{
-  const authenticated = useSelector((state: RootState) => state.auth.authenticated)
+export const PrivateRoute = () => {
+  const { authenticated, status } = useSelector((state: RootState) => state.auth)
+  const dispatch = useAppDispatch()
+
+  useEffect(() => {
+    if (status === "none") {
+      dispatch(checkToken())
+    }
+  }, [status, dispatch])
+
+  if (status === "loading" || status === 'none') {
+    return <p>Carregando...</p>
+  }
+
   return authenticated ? <Outlet /> : <Navigate to="/login" />;
 }

--- a/src/service/fetchAPI.ts
+++ b/src/service/fetchAPI.ts
@@ -6,7 +6,7 @@ import type { PerimetriaType } from "../types/PerimetriaType";
 
 const backendUrl = import.meta.env.VITE_BACKEND_URL
 
-const getToken = () => {
+export const getToken = () => {
   const token = localStorage.getItem('userToken')
   if (!token) {
     throw new Error("Token ausente, operação não permitida")
@@ -15,11 +15,23 @@ const getToken = () => {
   }
 }
 
+export const validateToken = async (token: string) => {
+  if (!backendUrl) {
+    throw new Error("Backend URL não configurado. Verifique o arquivo .env")
+  }
+
+  await axios.get<{ message: string }>(`${backendUrl}/auth/check-token`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    }
+  })
+}
+
 export const login = async (credentials: Adm): Promise<string> => {
   if (!backendUrl) {
     throw new Error("Backend URL não configurada. Verifique o arquivo .env")
   }
-  
+
   const { data } = await axios.post<{ message: string, token: string }>(`${backendUrl}/auth/login`, {
     email: credentials.email,
     password: credentials.password


### PR DESCRIPTION
Add to the backend a route to just check the token and update in the frontend, the authStore, fetchApi service and the PrivateRoute to make sure that the dashboard components will only be rendered  after the token validation, while the request is happening, render a loading component
